### PR TITLE
fix: git clone command in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 1. Clone this repository, and we'll call the directory that you cloned as ${POSE_ROOT}
 
    ```bash
-   git https://github.com/leijue222/Intra-and-Inter-Human-Relation-Network-for-MPEE.git
+   git clone https://github.com/leijue222/Intra-and-Inter-Human-Relation-Network-for-MPEE.git
    ```
 
 2. Install **Python=3.8 and PyTorch=1.10** from the PyTorch [official website](https://pytorch.org/get-started/locally/)


### PR DESCRIPTION
In step 1 of the installation process, the 'git clone' command was missing. It has been fixed in this request.